### PR TITLE
fix: PosixMmapReadableFile open writable file

### DIFF
--- a/src/util/env_posix.cc
+++ b/src/util/env_posix.cc
@@ -528,6 +528,7 @@ class PosixEnv : public Env {
     int fd = open(fname.c_str(), O_RDONLY);
     if (fd < 0) {
       s = IOError(fname, errno);
+#if 0
     } else if (mmap_limit_.Acquire()) {
       uint64_t size;
       s = GetFileSize(fname, &size);
@@ -543,6 +544,7 @@ class PosixEnv : public Env {
       if (!s.ok()) {
         mmap_limit_.Release();
       }
+#endif
     } else {
       *result = new PosixRandomAccessFile(fname, fd);
     }


### PR DESCRIPTION
如果PosixMmapReadableFile映射了一个可能被写的文件，当文件增加以后内存中的文件不会同步更新，读取新追加的数据会因为offset+size>length导致出现EINVAL错误。李多。
